### PR TITLE
Add charset to config fields and use it for constructing Mailbox

### DIFF
--- a/src/Lib/Driver/SMTPDriver.php
+++ b/src/Lib/Driver/SMTPDriver.php
@@ -25,7 +25,8 @@ class SMTPDriver
             $config['imap_path'],
             $config['username'],
             $config['password'],
-            realpath($config['attachments_dir'])
+            realpath($config['attachments_dir']),
+            $config['charset']
         );
 
         $this->numberOfRetries = $config['retry_counts'];

--- a/src/Module/Smtp.php
+++ b/src/Module/Smtp.php
@@ -23,6 +23,7 @@ class Smtp extends Module
         'retry_counts' => 3,
         'attachments_dir' => 'tests/_data',
         'auto_clear_attachments' => true,
+        'charset' => 'UTF-8',
     ];
 
     /** @var  SMTPDriver */


### PR DESCRIPTION
Some IMAP servers still default to `US-ACII`, hence the need to have the charset as a configurable field.