### PR TITLE
Fix formatting and add missing closing parenthesis

### DIFF
--- a/src/Module/Smtp.php
+++ b/src/Module/Smtp.php
@@ -154,7 +154,7 @@ class Smtp extends Module
      */
     public function seeTextInEmail($str)
     {
- 	$this->assertTrue($this->contains($str, $this->driver->getStringsByEmail($this->getCurrentMail()));
+        $this->assertTrue($this->contains($str, $this->driver->getStringsByEmail($this->getCurrentMail())));
     }
 
     /**


### PR DESCRIPTION
The missing parenthesis is causing a PHP Parse error in version 0.8.0.

I also changed the tab indentation to be spaces to better match the rest of the file.