### PR TITLE
Codeception 5 compatibility

### DIFF
--- a/src/Module/Smtp.php
+++ b/src/Module/Smtp.php
@@ -3,6 +3,7 @@ namespace Codeception\Module;
 
 use Codeception\Exception\ModuleException;
 use Codeception\Lib\Driver\SMTPDriver;
+use Codeception\Lib\ModuleContainer;
 use Codeception\Module;
 use PhpImap\IncomingMail;
 
@@ -11,26 +12,27 @@ use PhpImap\IncomingMail;
  */
 class Smtp extends Module
 {
-    /** @var array */
-    protected $requiredFields = ['username', 'password'];
-
-    /** @var array */
-    protected $config = [
-        'username',
-        'password',
-        'imap_path' => '{imap.gmail.com:993/imap/ssl}INBOX',
-        'wait_interval' => 1, //in seconds
-        'retry_counts' => 3,
-        'attachments_dir' => 'tests/_data',
-        'auto_clear_attachments' => true,
-        'charset' => 'UTF-8',
-    ];
-
     /** @var  SMTPDriver */
     protected $driver;
 
     /** @var  IncomingMail */
     protected $mail;
+
+    public function __construct(ModuleContainer $moduleContainer, ?array $config = null)
+    {
+        $this->requiredFields = ['username', 'password'];
+        $this->config = [
+            'username',
+            'password',
+            'imap_path' => '{imap.gmail.com:993/imap/ssl}INBOX',
+            'wait_interval' => 1, //in seconds
+            'retry_counts' => 3,
+            'attachments_dir' => 'tests/_data',
+            'auto_clear_attachments' => true,
+            'charset' => 'UTF-8',
+        ];
+        parent::__construct($moduleContainer, $config);
+    }
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
In Codeception 5, there are `array` property typehints for `$requiredFields` and `$config`.
https://github.com/Codeception/Codeception/blob/5.1/src/Codeception/Module.php#L49
Assigning it inside constructor fixes the compatibility without any BC break.
Typehint could be added OFC to make it compatible, but then it would be compatible with Codeception 5 only.

If releasing a new version compatible with Codeception 5 only was preferred, then cherry-picking commit from this fork may be a better option https://github.com/pryzmatpl/codeception-smtp-mail/commit/3f16f823bef6af9df730171b4c87d3669722ce0f